### PR TITLE
Set Environment with Command Line Argument

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,6 +1,5 @@
 
 KNACK_APP = {
-    "app_id": "595d00ebd315cc4cb98daff4",
     "api_view": {"scene": "scene_127", "view": "view_248", "ref_obj": ["object_24"]},
     "api_form": {"scene": "scene_131", "view": "view_252"},
 }

--- a/config/secrets_template.py
+++ b/config/secrets_template.py
@@ -1,6 +1,21 @@
-# create a `secrets.py` file that looks like this
-API_KEY = "abc123"
-GITHUB_USER ="mygithubusername"
-GITHUB_PASSWORD = "thisisnotapassword"
-KNACK_USERNAME = "suzy.q@austintexas.gov"
-KNACK_PASSWORD = "verylongandsecureknackpasswordforsecuritysafety"
+# create a `secrets.py` file that looks like thisAPI_KEY = "abc123xyz"
+GITHUB_USER ="abc123xyz"
+
+GITHUB_PASSWORD = "abc123xyz"
+
+KNACK_CREDS = {
+    "prod" : {
+        "password" : "abc123xyz" ,
+        "username" : "abc123xyz@austintexas.gov",
+        "app_id" : "abc123xyz",
+        "api_key" : "abc123xyz",
+    },
+    "test" : {
+        "password" : "abc123xyz" ,
+        "username" : "abc123xyz@austintexas.gov",
+        "app_id" : "abc123xyz",
+        "api_key" : "abc123xyz",
+    }
+}
+
+ZENHUB_ACCESS_TOKEN = "abc123xyz"

--- a/config/secrets_template.py
+++ b/config/secrets_template.py
@@ -1,4 +1,5 @@
-# create a `secrets.py` file that looks like thisAPI_KEY = "abc123xyz"
+# create a `secrets.py` file that looks like this
+
 GITHUB_USER ="abc123xyz"
 
 GITHUB_PASSWORD = "abc123xyz"

--- a/intake.py
+++ b/intake.py
@@ -18,11 +18,7 @@ import knackpy
 import requests
 
 from config.config import ASSIGNEES, KNACK_APP, FIELDS
-from config.secrets import (
-    GITHUB_USER,
-    GITHUB_PASSWORD,
-    KNACK_CREDS,
-)
+from config.secrets import GITHUB_USER, GITHUB_PASSWORD, KNACK_CREDS
 import _transforms
 
 
@@ -277,7 +273,7 @@ def form_submit(token, app_id, scene, view, payload):
 def main():
 
     args = cli_args()
-    
+
     env = args.env
 
     KNACK_USERNAME = KNACK_CREDS[env].get("username")

--- a/intake.py
+++ b/intake.py
@@ -340,10 +340,10 @@ def main():
             # trigger an email notificaiton
 
             token = get_token(KNACK_USERNAME, KNACK_PASSWORD, KNACK_APP_ID)
-
+            
             response = form_submit(
                 token,
-                KNACK_APP["app_id"],
+                KNACK_APP_ID,
                 KNACK_APP["api_form"]["scene"],
                 KNACK_APP["api_form"]["view"],
                 knack_payload,


### PR DESCRIPTION
Fixes #12 by adding a required `-e/--env` flag which must be set to either `prod` or `test`. The environment applies to the *knack application only*, the service bot will still publish issues to  our "production" repos.

So now to run the intake script you do this:
```bash
$ python intake.py -e prod
```
or this:
```bash
$ python intake.py -e test
```

The test service request submit form is [here](https://atd.knack.com/26-nov-2019-test-data-and-technology-services-portal#new-service-request/)