### PR TITLE
Stop using vision zero editor label

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -180,7 +180,7 @@ FIELDS = [
             "Signs & Markings Operations": "Product: Signs & Markings",
             "ArcGIS": "Service: Geo",
             "Vision Zero in Action": "Product: Vision Zero in Action",
-            "Vision Zero (Editor)": "Product: Vision Zero Editor",
+            "Vision Zero (Editor)": "Product: Vision Zero Crash Data System",
             "Vision Zero (Viewer)": "Product: Vision Zero Viewer",
             "Transportation Development Services (TDS)": "Product: TDS Portal",
             "Parking Enterprise Portal": "Product: Parking Enterprise Portal",


### PR DESCRIPTION
Fixes [#7383](https://github.com/cityofaustin/atd-data-tech/issues/7383).

Will use `Product: Vision Zero Crash Data System` for all VZD and VZE issues.