### PR TITLE
Moving Some Socrata details to Environment Variables

### DIFF
--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -16,6 +16,7 @@ WORKSPACE_ID = "5caf7dc6ecad11531cc418ef"
 SOCRATA_RESOURCE_ID = "rzwg-fyv8"
 ZENHUB_ACCESS_TOKEN = os.environ["ZENHUB_ACCESS_TOKEN"]
 GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
+SOCRATA_ENDPOINT = os.environ["SOCRATA_ENDPOINT"]
 SOCRATA_API_KEY_ID = os.environ["SOCRATA_API_KEY_ID"]
 SOCRATA_API_KEY_SECRET = os.environ["SOCRATA_API_KEY_SECRET"]
 SOCRATA_APP_TOKEN = os.environ["SOCRATA_APP_TOKEN"]
@@ -126,7 +127,7 @@ def main():
         )
 
     client = sodapy.Socrata(
-        "data.austintexas.gov",
+        SOCRATA_ENDPOINT,
         SOCRATA_APP_TOKEN,
         username=SOCRATA_API_KEY_ID,
         password=SOCRATA_API_KEY_SECRET,

--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -13,7 +13,7 @@ import sodapy
 
 REPO = {"id": 140626918, "name": "cityofaustin/atd-data-tech"}
 WORKSPACE_ID = "5caf7dc6ecad11531cc418ef"
-SOCRATA_RESOURCE_ID = "rzwg-fyv8"
+SOCRATA_RESOURCE_ID = os.environ["SOCRATA_RESOURCE_ID"]
 ZENHUB_ACCESS_TOKEN = os.environ["ZENHUB_ACCESS_TOKEN"]
 GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
 SOCRATA_ENDPOINT = os.environ["SOCRATA_ENDPOINT"]


### PR DESCRIPTION
Moving Socrata endpoint and resource ID (AKA 4x4) to environment variables. 

Will merge this to production once we get https://github.com/cityofaustin/atd-prefect/pull/41 merged along with deactivating the airflow DAG.

I'll add these to our Prefect KV store for atd-service-bot as well.

Will be good to do this to other scripts where we have hard-coded any Socrata resource IDs or endpoints as these may change with the migration to the EDP coming in January. In the case of Prefect, we can just update the KV store and things _*should*_ keep running.