### PR TITLE
Remove HTML comments, which often hide email addresses, from DTS GitHub issue dataset on the Open Data Portal

### DIFF
--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -45,11 +45,6 @@ def remove_html_comments(text):
     # Remove HTML comments using regular expression
     return re.sub(r'<!--(.*?)-->', '', text, flags=re.DOTALL)
 
-def preprocess_issue_description(description):
-    # Apply both transformations
-    description = remove_html_comments(description)
-    return description
-
 def issue_to_dict(issue):
     """breakdown pygithub classes into dicts"""
     issue_dict = {}
@@ -76,7 +71,7 @@ def issue_to_dict(issue):
         issue_dict[attr] = getattr(issue, attr)
     
     # Preprocess issue description using the new function
-    issue_dict["body"] = preprocess_issue_description(issue_dict["body"])
+    issue_dict["body"] = remove_html_comments(issue_dict["body"])
     
     return issue_dict
 

--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -34,7 +34,7 @@ def extract_workgroups_from_labels(labels):
     return ", ".join(workgroup_labels_no_prefix) or None
 
 
-def get_github_issues(repo_name, github_access_token, state="open"):
+def get_github_issues(repo_name, github_access_token, state="all"):
     g = Github(github_access_token)
     repo = g.get_repo(repo_name)
     issues_metadata = repo.get_issues(state=state)

--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -22,6 +22,7 @@ SOCRATA_API_KEY_ID = os.environ["SOCRATA_API_KEY_ID"]
 SOCRATA_API_KEY_SECRET = os.environ["SOCRATA_API_KEY_SECRET"]
 SOCRATA_APP_TOKEN = os.environ["SOCRATA_APP_TOKEN"]
 
+
 def extract_workgroups_from_labels(labels):
     """Extract a comma-separated list of workgroup names from "Workgroup: Xyz" labels"""
     workgroup_labels = list(
@@ -39,11 +40,13 @@ def get_github_issues(repo_name, github_access_token, state="open"):
     issues_metadata = repo.get_issues(state=state)
     return [issue for issue in issues_metadata]
 
+
 def remove_html_comments(text):
     if not isinstance(text, str):
         return text  # Return as-is if not a string
     # Remove HTML comments using regular expression
-    return re.sub(r'<!--(.*?)-->', '', text, flags=re.DOTALL)
+    return re.sub(r"<!--(.*?)-->", "", text, flags=re.DOTALL)
+
 
 def issue_to_dict(issue):
     """breakdown pygithub classes into dicts"""
@@ -69,10 +72,10 @@ def issue_to_dict(issue):
         "url",
     ]:
         issue_dict[attr] = getattr(issue, attr)
-    
+
     # Preprocess issue description using the new function
     issue_dict["body"] = remove_html_comments(issue_dict["body"])
-    
+
     return issue_dict
 
 


### PR DESCRIPTION
This PR closes: https://github.com/cityofaustin/atd-data-tech/issues/12802
Detail: I had some trouble understanding the goal of the issue, so my implementation might not be complete.
The PR is tested on the TEST dataset: https://datahub.austintexas.gov/Transportation-and-Mobility/TEST-ATD-Data-Tech-Services-Issues/93ru-6p6e 
Here is the description: 
Please see [this conversation](https://austininnovation.slack.com/archives/CHZE6BC6L/p1689024141852599?thread_ts=1689023466.111509&cid=CHZE6BC6L), beginning with @dianamartin's observation about email addresses being published. Thanks for bringing this up!

This issue is to track the removal of those, potentially though parsing the contents as HTML and removing comments. This transformation may belong in the ETL scripts which maintain these datasets.

Note: This task is to hide HTML comments, not email addresses. The intent here is to empower the service desk operator to hide or not hide details found in a GitHub issue before it is sent on to our [open data portal](https://data.austintexas.gov/Transportation-and-Mobility/ATD-Data-Tech-Services-Issues/rzwg-fyv8). Additionally, this is to confirm that the data set is truncated on the ODP and all past and present issues are processed with this new eye to hide comments.