### PR TITLE
Update GIS label mapping

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -193,7 +193,7 @@ FIELDS = [
             "GIS Data": ["Service: Geo", "Type: Data"],
             "ArcGIS Training": ["Service: Geo", "Type: Training"],
             "ArcGIS Online Access": ["Service: Geo", "Type: IT Support"],
-            "ArcGIS Online Support": ["Type: IT Support", "Type: Data"],
+            "ArcGIS Online Support": ["Service: Geo", "Type: Data"],
             "ArcGIS Pro Support": ["Service: Geo", "Type: Data"],
             "ArcGIS Pro Installation": ["Service: Geo", "Type: IT Support"],
         },

--- a/config/config.py
+++ b/config/config.py
@@ -187,15 +187,15 @@ FIELDS = [
     {
         "knack": "field_",  # What do you need?
         "github": "labels",
-        "method": "map_append",
+        "method": "map_append_all",
         "map": {
-            "Map": "Service: Geo",
-            "GIS Data": "Service: Geo",
-            "ArcGIS Training": "Service: Geo",
-            "ArcGIS Online Access": "Service: Geo",
-            "ArcGIS Online Support": "Type: IT Support",
-            "ArcGIS Pro Support": "Service: Geo",
-            "ArcGIS Pro Installation": "Service: Geo",
+            "Map": ["Service: Geo", "Type: Map Request"],
+            "GIS Data": ["Service: Geo", "Type: Data"],
+            "ArcGIS Training": ["Service: Geo", "Type: Training"],
+            "ArcGIS Online Access": ["Service: Geo", "Type: IT Support"],
+            "ArcGIS Online Support": ["Type: IT Support", "Type: Data"],
+            "ArcGIS Pro Support": ["Service: Geo", "Type: Data"],
+            "ArcGIS Pro Installation": ["Service: Geo", "Type: IT Support"],
         },
     },
     {

--- a/config/config.py
+++ b/config/config.py
@@ -178,10 +178,24 @@ FIELDS = [
         "map": {
             "Bug Report — Something is not working": "Type: Bug Report",
             "Feature or Enhancement — An application I use could be improved": "Type: Enhancement",
-            "GIS or Maps": "Service: Geo",
+            "Geospatial Services (GIS, Maps, etc.)": "Service: Geo",
             "New Project — My needs are not met by the technology & data available to me": "Type: New Application",
             "IT Support — Help with licenses, accounts, hardware, etc.": "Type: IT Support",
             "Something Else": "Type: Other",
+        },
+    },
+    {
+        "knack": "field_",  # What do you need?
+        "github": "labels",
+        "method": "map_append",
+        "map": {
+            "Map": "Service: Geo",
+            "GIS Data": "Service: Geo",
+            "ArcGIS Training": "Service: Geo",
+            "ArcGIS Online Access": "Service: Geo",
+            "ArcGIS Online Support": "Type: IT Support",
+            "ArcGIS Pro Support": "Service: Geo",
+            "ArcGIS Pro Installation": "Service: Geo",
         },
     },
     {

--- a/config/config.py
+++ b/config/config.py
@@ -185,7 +185,7 @@ FIELDS = [
         },
     },
     {
-        "knack": "field_",  # What do you need?
+        "knack": "field_641",  # What do you need?
         "github": "labels",
         "method": "map_append_all",
         "map": {

--- a/intake.py
+++ b/intake.py
@@ -115,10 +115,11 @@ def map_issue(issue, fields):
                 github_issue[field["github"]].append(val_mapped)
 
         elif field["method"] == "map_append_all":
-            val_mapped = field["map"].get(knack_field_value)
+            vals_mapped = field["map"].get(knack_field_value)
 
-            if val_mapped:
-                github_issue[field["github"]].append(val_mapped)
+            if vals_mapped:
+                for val_mapped in vals_mapped:
+                    github_issue[field["github"]].append(val_mapped)
 
         elif field["method"] == "copy":
             github_issue[field["github"]] = knack_field_value

--- a/intake.py
+++ b/intake.py
@@ -114,6 +114,12 @@ def map_issue(issue, fields):
             if val_mapped:
                 github_issue[field["github"]].append(val_mapped)
 
+        elif field["method"] == "map_append_all":
+            val_mapped = field["map"].get(knack_field_value)
+
+            if val_mapped:
+                github_issue[field["github"]].append(val_mapped)
+
         elif field["method"] == "copy":
             github_issue[field["github"]] = knack_field_value
 


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/13406

This PR extends the service bot config and how it is handled so that we can apply multiple GitHub labels to a new GH issue from a single field value in the Knack app.

In the real word, this work like:
1. Service requester chooses `Map` option for `What do you need?` question in service request form
2. Service bot sees new Knack record and uses chosen `Map` option + the script config to add `Service: Geo` and `Type: Map Request` GitHub labels to the new issue payload
3. New issue is created by the script with the defined labels and the Geo team takes it from there 🦸 

**Testing**
We can't test this yet, but we have a meeting set up for Monday to apply the changes needed in the Knack app, deploy this code, and make sure everything is working. We will test with service requests then, and I'll patch if needed.