### PR TITLE
Include index issues comments in dts portal

### DIFF
--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -67,18 +67,6 @@ def find_knack_record_by_issue(knack_records, issue_number):
     return None
 
 
-def are_timestamps_different(knack_timestamp, issue_timestamp):
-    """
-    Returns true if the stored comment timestamp in knack differs from the issues timestamp
-    """
-    if not knack_timestamp:
-        if issue_timestamp:
-            return True
-        else:
-            return False
-    return knack_timestamp["date"] != issue_timestamp.strftime("%m/%d/%Y")
-
-
 def build_payload(project_records, project_issues):
     """
     Build a payload to update knack records based on github issues and Zenhub metadata.
@@ -117,7 +105,7 @@ def build_payload(project_records, project_issues):
             issue_payload = {"id": knack_record["id"]}
             title_knack = knack_record[KNACK_TITLE_FIELD]
             pipeline_knack = knack_record[KNACK_PIPELINE_FIELD]
-            last_comment_date_knack = knack_record[KNACK_COMMENT_DATE_FIELD]
+            last_comment_knack = knack_record[KNACK_COMMENT_FIELD]
             assignee_knack = (
                 knack_record[KNACK_ISSUE_ASSIGNEE]
                 if knack_record[KNACK_ISSUE_ASSIGNEE]
@@ -130,7 +118,7 @@ def build_payload(project_records, project_issues):
             if pipeline_knack != pipeline:
                 issue_payload[KNACK_PIPELINE_FIELD] = pipeline
                 update_record = True
-            if are_timestamps_different(last_comment_date_knack, last_comment_date):
+            if last_comment_knack != last_comment_body:
                 issue_payload[KNACK_COMMENT_FIELD] = last_comment_body
                 issue_payload[KNACK_COMMENT_DATE_FIELD] = str(last_comment_date)
                 update_record = True

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -15,6 +15,7 @@ import sys
 from github import Github
 import requests
 import knackpy
+import markdown
 
 
 ZENHUB_REPO = {"id": 140626918, "name": "cityofaustin/atd-data-tech"}
@@ -96,6 +97,7 @@ def build_payload(project_records, project_issues):
         if len(comments_list) > 0:
             last_comment = comments_list[-1]
             last_comment_body = last_comment.body
+            last_comment_body = markdown.markdown(last_comment_body)
             last_comment_date = last_comment.created_at
 
         # ZH metadata does not include closed issues

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -28,6 +28,8 @@ KNACK_OBJ = "object_30"
 KNACK_TITLE_FIELD = "field_538"
 KNACK_ISSUE_NUMBER_FIELD = "field_492"
 KNACK_PIPELINE_FIELD = "field_649"  # production
+KNACK_COMMENT_FIELD = "field_688"
+KNACK_COMMENT_DATE_FIELD = "field_689"
 
 
 def get_zenhub_metadata(workspace_id, token, repo_id, timeout=60):
@@ -77,6 +79,18 @@ def build_payload(project_records, project_issues):
     payload = []
     for issue in project_issues:  # iterate over gh issues
         pipeline = find_pipeline_by_issue(zenhub_metadata, issue.number)
+        last_comment_body = None
+        last_comment_date = None
+
+        comments = issue.get_comments()
+        comments_list = [comment for comment in comments]
+        if len(comments_list) > 0:
+            last_comment = comments_list[-1]
+            if str(issue.number) != last_comment.issue_url[-5:]:
+                print("NO", issue.number, last_comment.issue_url[-5:])
+            last_comment_body = last_comment.body
+            last_comment_date = last_comment.created_at
+            print(issue.number, comments_list[-1].body, comments_list[-1].created_at, comments_list[-1].issue_url)
 
         # ZH metadata does not include closed issues
         if issue.state == "closed":
@@ -85,16 +99,25 @@ def build_payload(project_records, project_issues):
         knack_record = find_knack_record_by_issue(project_records, issue.number)
 
         if knack_record:
+            update_record = False
             issue_payload = {"id": knack_record["id"]}
             title_knack = knack_record[KNACK_TITLE_FIELD]
             pipeline_knack = knack_record[KNACK_PIPELINE_FIELD]
+            last_comment_date_knack = knack_record[KNACK_COMMENT_DATE_FIELD]
 
             if title_knack != issue.title:
                 issue_payload[KNACK_TITLE_FIELD] = issue.title
+                update_record = True
             if pipeline_knack != pipeline:
                 issue_payload[KNACK_PIPELINE_FIELD] = pipeline
-            if title_knack != issue.title or pipeline_knack != pipeline:
+                update_record = True
+            if last_comment_date_knack != last_comment_date:
+                issue_payload[KNACK_COMMENT_FIELD] = last_comment_body
+                issue_payload[KNACK_COMMENT_DATE_FIELD] = str(last_comment_date)
+                update_record = True
+            if update_record:
                 payload.append(issue_payload)
+
         else:
             issue_payload = {
                 KNACK_ISSUE_NUMBER_FIELD: issue.number,
@@ -102,6 +125,10 @@ def build_payload(project_records, project_issues):
             }
             if pipeline is not None:
                 issue_payload[KNACK_PIPELINE_FIELD] = pipeline
+            if last_comment_body is not None:
+                issue_payload[KNACK_COMMENT_FIELD] = last_comment_body
+                issue_payload[KNACK_COMMENT_DATE_FIELD] = str(last_comment_date)
+
             payload.append(issue_payload)
     return payload
 

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -79,18 +79,15 @@ def build_payload(project_records, project_issues):
     payload = []
     for issue in project_issues:  # iterate over gh issues
         pipeline = find_pipeline_by_issue(zenhub_metadata, issue.number)
+
         last_comment_body = None
         last_comment_date = None
-
         comments = issue.get_comments()
         comments_list = [comment for comment in comments]
         if len(comments_list) > 0:
             last_comment = comments_list[-1]
-            if str(issue.number) != last_comment.issue_url[-5:]:
-                print("NO", issue.number, last_comment.issue_url[-5:])
             last_comment_body = last_comment.body
             last_comment_date = last_comment.created_at
-            print(issue.number, comments_list[-1].body, comments_list[-1].created_at, comments_list[-1].issue_url)
 
         # ZH metadata does not include closed issues
         if issue.state == "closed":

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -76,7 +76,7 @@ def are_timestamps_different(knack_timestamp, issue_timestamp):
             return True
         else:
             return False
-    return knack_timestamp['date'] != issue_timestamp.strftime('%m/%d/%Y')
+    return knack_timestamp["date"] != issue_timestamp.strftime("%m/%d/%Y")
 
 
 def build_payload(project_records, project_issues):
@@ -118,7 +118,11 @@ def build_payload(project_records, project_issues):
             title_knack = knack_record[KNACK_TITLE_FIELD]
             pipeline_knack = knack_record[KNACK_PIPELINE_FIELD]
             last_comment_date_knack = knack_record[KNACK_COMMENT_DATE_FIELD]
-            assignee_knack = knack_record[KNACK_ISSUE_ASSIGNEE] if knack_record[KNACK_ISSUE_ASSIGNEE] else ""
+            assignee_knack = (
+                knack_record[KNACK_ISSUE_ASSIGNEE]
+                if knack_record[KNACK_ISSUE_ASSIGNEE]
+                else ""
+            )
 
             if title_knack != issue.title:
                 issue_payload[KNACK_TITLE_FIELD] = issue.title

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -160,6 +160,7 @@ def main():
     logging.info("Starting...")
 
     # setup and get the knack records
+    logging.info("Downloading records from Knack")
     app = knackpy.App(app_id=KNACK_APP_ID, api_key=KNACK_API_KEY)
     project_records = app.get(KNACK_OBJ)
 
@@ -168,10 +169,12 @@ def main():
     repo = g.get_repo(REPO)
 
     # iterate over the github client's issues and build our working data
+    logging.info("Downloading issues from github")
     project_issues_paginator = repo.get_issues(state="all", labels=["Project Index"])
     project_issues = [issue for issue in project_issues_paginator]
 
     # build the payload out of the github and knack state of the data
+    logging.info("Building payload...")
     knack_payload = build_payload(
         project_records,
         project_issues,

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -28,9 +28,13 @@ KNACK_OBJ = "object_30"
 KNACK_TITLE_FIELD = "field_538"
 KNACK_ISSUE_NUMBER_FIELD = "field_492"
 KNACK_PIPELINE_FIELD = "field_649"  # production
-KNACK_COMMENT_FIELD = "field_688"  # staging field
-KNACK_COMMENT_DATE_FIELD = "field_689"  # staging field
-KNACK_ISSUE_ASSIGNEE = "field_690"  # staging field
+KNACK_COMMENT_FIELD = "field_674"
+KNACK_COMMENT_DATE_FIELD = "field_676"
+KNACK_ISSUE_ASSIGNEE = "field_675"
+
+# KNACK_COMMENT_FIELD = "field_688"  # staging field
+# KNACK_COMMENT_DATE_FIELD = "field_689"  # staging field
+# KNACK_ISSUE_ASSIGNEE = "field_690"  # staging field
 
 
 def get_zenhub_metadata(workspace_id, token, repo_id, timeout=60):

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -28,8 +28,9 @@ KNACK_OBJ = "object_30"
 KNACK_TITLE_FIELD = "field_538"
 KNACK_ISSUE_NUMBER_FIELD = "field_492"
 KNACK_PIPELINE_FIELD = "field_649"  # production
-KNACK_COMMENT_FIELD = "field_688"
-KNACK_COMMENT_DATE_FIELD = "field_689"
+KNACK_COMMENT_FIELD = "field_688"  # staging field
+KNACK_COMMENT_DATE_FIELD = "field_689"  # staging field
+KNACK_ISSUE_ASSIGNEE = "field_690"  # staging field
 
 
 def get_zenhub_metadata(workspace_id, token, repo_id, timeout=60):
@@ -66,6 +67,18 @@ def find_knack_record_by_issue(knack_records, issue_number):
     return None
 
 
+def are_timestamps_different(knack_timestamp, issue_timestamp):
+    """
+    Returns true if the stored comment timestamp in knack differs from the issues timestamp
+    """
+    if not knack_timestamp:
+        if issue_timestamp:
+            return True
+        else:
+            return False
+    return knack_timestamp['date'] != issue_timestamp.strftime('%m/%d/%Y')
+
+
 def build_payload(project_records, project_issues):
     """
     Build a payload to update knack records based on github issues and Zenhub metadata.
@@ -83,6 +96,10 @@ def build_payload(project_records, project_issues):
         last_comment_body = None
         last_comment_date = None
         comments = issue.get_comments()
+        # an issue often has more than one assignee, this returns the list of users assigned to the issue
+        assignees = issue.assignees
+        assignees_logins = [user.login for user in assignees]
+        assignees_string = " ".join(assignees_logins)
         comments_list = [comment for comment in comments]
         if len(comments_list) > 0:
             last_comment = comments_list[-1]
@@ -101,6 +118,7 @@ def build_payload(project_records, project_issues):
             title_knack = knack_record[KNACK_TITLE_FIELD]
             pipeline_knack = knack_record[KNACK_PIPELINE_FIELD]
             last_comment_date_knack = knack_record[KNACK_COMMENT_DATE_FIELD]
+            assignee_knack = knack_record[KNACK_ISSUE_ASSIGNEE] if knack_record[KNACK_ISSUE_ASSIGNEE] else ""
 
             if title_knack != issue.title:
                 issue_payload[KNACK_TITLE_FIELD] = issue.title
@@ -108,9 +126,12 @@ def build_payload(project_records, project_issues):
             if pipeline_knack != pipeline:
                 issue_payload[KNACK_PIPELINE_FIELD] = pipeline
                 update_record = True
-            if last_comment_date_knack != last_comment_date:
+            if are_timestamps_different(last_comment_date_knack, last_comment_date):
                 issue_payload[KNACK_COMMENT_FIELD] = last_comment_body
                 issue_payload[KNACK_COMMENT_DATE_FIELD] = str(last_comment_date)
+                update_record = True
+            if assignee_knack != assignees_string:
+                issue_payload[KNACK_ISSUE_ASSIGNEE] = assignees_string
                 update_record = True
             if update_record:
                 payload.append(issue_payload)
@@ -119,6 +140,7 @@ def build_payload(project_records, project_issues):
             issue_payload = {
                 KNACK_ISSUE_NUMBER_FIELD: issue.number,
                 KNACK_TITLE_FIELD: issue.title,
+                KNACK_ISSUE_ASSIGNEE: assignees_string,
             }
             if pipeline is not None:
                 issue_payload[KNACK_PIPELINE_FIELD] = pipeline

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ knackpy==1.0.*
 pygithub==1.53.*
 requests==2.24.*
 sodapy==2.1.*
+markdown==3.7.*


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/17974#

The product team needs to be able to easily see the most recent comment on project indices. I added some steps to the gh issues to knack script to get the data the PMs need. 

I added three new columns to `object_30` Project Evaluation in the TEST | 26 APR 2024 | DTS | Data and Technology Services Portal app. 
* Most recent comment, type: paragraph text
* Comment date, type: date/time
* Issue assignees, type: string

I created a new page to display those columns
https://atd.knack.com/test--26-apr-2024--dts--data-and-technology-services-portal#current-projects/

~~The same steps need to be repeated in the prod app, once it is approved.~~
*update! Karo improved my work and added it all to the prod app.* 
You can see it here in prod: https://atd.knack.com/dts#current-projects/ (behind a login)


![Screenshot 2024-08-26 at 5 08 24 PM](https://github.com/user-attachments/assets/debb1160-6f92-4fd3-93d4-6b02e62cc599)


### To Test

You need the following environment variables from 1pw
ZENHUB_ACCESS_TOKEN
GITHUB_ACCESS_TOKEN
and the knack api key and application id for the DTS Portal, prod

With those variables, run `gh_index_issues_to_dts_portal.py`. Change comments or project assignees data in the Project Evaluations table in the knack builder to force records to update. (Or ask me to do it and I can change it for you) 