### PR TITLE
Add github assignees to socrata payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+/.idea

--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -56,7 +56,7 @@ def issue_to_dict(issue):
 
     issue_dict["labels"] = ", ".join([label.name for label in issue.labels])
 
-    issue_dict["assignee_usernames"] = ", ".join([user.login for user in issue.assignees])
+    issue_dict["assignee_ids"] = ", ".join([str(user.id) for user in issue.assignees])
 
     issue_dict["milestone"] = (
         None if not getattr(issue, "milestone") else issue.milestone.title

--- a/issues_to_socrata.py
+++ b/issues_to_socrata.py
@@ -56,6 +56,8 @@ def issue_to_dict(issue):
 
     issue_dict["labels"] = ", ".join([label.name for label in issue.labels])
 
+    issue_dict["assignee_usernames"] = ", ".join([user.login for user in issue.assignees])
+
     issue_dict["milestone"] = (
         None if not getattr(issue, "milestone") else issue.milestone.title
     )


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/23189

Adding comma-separated list of github user IDs assigned to an issue to the socrata dataset.

[Test dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Test-Transportation-and-Public-Works-Data-and-Tech/93ru-6p6e/about_data) has the new column loaded. 

- [x] Reminder to add `assignee_ids` column to production socrata dataset before deploying
