### PR TITLE
Remove zenhub from the gh to knack script

### DIFF
--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -16,7 +16,6 @@ from github import Github
 import knackpy
 import markdown
 
-WORKSPACE_ID = "5caf7dc6ecad11531cc418ef"
 KNACK_API_KEY = os.environ["KNACK_API_KEY"]
 KNACK_APP_ID = os.environ["KNACK_APP_ID"]
 GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]

--- a/gh_index_issues_to_dts_portal.py
+++ b/gh_index_issues_to_dts_portal.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-""" Create or update "Index" issues in the DTS Portal from Github.
+"""Create or update "Index" issues in the DTS Portal from Github.
 
 We use the DTS portal to track our project (aka "Index" issue) scoring. This
 script keeps the issue titles in the DTS portal in sync with Github by fetching these
 issues from the atd-data-tech repo and either creating new project records in the DTS
-portal or updating existing project records if their title or pipeline status does 
+portal or updating existing project records if their title or pipeline status does
 not match the title of the issue on Github."""
 
 import logging
@@ -13,14 +13,10 @@ import os
 import sys
 
 from github import Github
-import requests
 import knackpy
 import markdown
 
-
-ZENHUB_REPO = {"id": 140626918, "name": "cityofaustin/atd-data-tech"}
 WORKSPACE_ID = "5caf7dc6ecad11531cc418ef"
-ZENHUB_ACCESS_TOKEN = os.environ["ZENHUB_ACCESS_TOKEN"]
 KNACK_API_KEY = os.environ["KNACK_API_KEY"]
 KNACK_APP_ID = os.environ["KNACK_APP_ID"]
 GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
@@ -38,29 +34,6 @@ KNACK_ISSUE_ASSIGNEE = "field_675"
 # KNACK_ISSUE_ASSIGNEE = "field_690"  # staging field
 
 
-def get_zenhub_metadata(workspace_id, token, repo_id, timeout=60):
-    """
-    Fetch Zenhub metadata for a given repo.
-    """
-    url = f"https://api.zenhub.com/p2/workspaces/{workspace_id}/repositories/{repo_id}/board"
-    params = {"access_token": token}
-    res = requests.get(url, params=params, timeout=timeout)
-    res.raise_for_status()
-    return res.json()
-
-
-def find_pipeline_by_issue(data, issue_number):
-    """
-    Find the pipeline for a given issue number in the Zenhub metadata.
-    Return None if none found.
-    """
-    for pipeline in data["pipelines"]:
-        for issue in pipeline["issues"]:
-            if issue["issue_number"] == issue_number:
-                return pipeline["name"]
-    return None
-
-
 def find_knack_record_by_issue(knack_records, issue_number):
     """
     Find a knack record by issue number.
@@ -74,18 +47,15 @@ def find_knack_record_by_issue(knack_records, issue_number):
 
 def build_payload(project_records, project_issues):
     """
-    Build a payload to update knack records based on github issues and Zenhub metadata.
+    Build a payload to update knack records based on github issues.
     Take care to create the payload for each issue so that it will work as a create or
     update call depending on if the record already exists in the Knack app.
     """
-    zenhub_metadata = get_zenhub_metadata(
-        WORKSPACE_ID, ZENHUB_ACCESS_TOKEN, ZENHUB_REPO["id"]
-    )
 
     payload = []
     for issue in project_issues:  # iterate over gh issues
-        pipeline = find_pipeline_by_issue(zenhub_metadata, issue.number)
-
+        # temporarily setting pipeline as None until we get issue fields
+        pipeline = None
         last_comment_body = None
         last_comment_date = None
         comments = issue.get_comments()
@@ -121,7 +91,7 @@ def build_payload(project_records, project_issues):
             if title_knack != issue.title:
                 issue_payload[KNACK_TITLE_FIELD] = issue.title
                 update_record = True
-            if pipeline_knack != pipeline:
+            if pipeline and pipeline_knack != pipeline:
                 issue_payload[KNACK_PIPELINE_FIELD] = pipeline
                 update_record = True
             if last_comment_knack != last_comment_body:


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/27040

Removing the zenhub aspect from the script that pushes issues labeled "Project Index" to the DTS Portal. 

Amenity said the pipeline isnt an important part of the DTS Portal table and we can wait until github fields